### PR TITLE
Implement register ranges with persistent config

### DIFF
--- a/SW/ESPlan_RS485_ModbusTCP_Gateway/index.h
+++ b/SW/ESPlan_RS485_ModbusTCP_Gateway/index.h
@@ -15,7 +15,7 @@ const char index_html[] PROGMEM = R"rawliteral(
         Baud <input id='baud' name='baud'><br>
         Port <input id='port' name='port'><br>
         <table id='map'>
-            <tr><th>Slave</th><th>Reg</th><th>TCP</th><th></th><th></th></tr>
+            <tr><th>Slave</th><th>Reg</th><th>Len</th><th>TCP</th><th></th><th></th></tr>
         </table>
         <button type='button' id='add'>+</button><br>
         <input type='submit' id='save' value='Save'>

--- a/SW/ESPlan_RS485_ModbusTCP_Gateway/script.h
+++ b/SW/ESPlan_RS485_ModbusTCP_Gateway/script.h
@@ -6,6 +6,7 @@ function addRow(item){
   var r=t.insertRow(-1);
   r.innerHTML="<td><input class='s' type='number' min='1' value='"+(item?item.s:1)+"'></td>"+
              "<td><input class='r' type='number' min='0' value='"+(item?item.r:0)+"'></td>"+
+             "<td><input class='n' type='number' min='1' value='"+(item?item.n:1)+"'></td>"+
              "<td><input class='t' type='number' min='0' value='"+(item?item.t:0)+"'></td>"+
              "<td><button type='button' onclick='delRow(this)'>-</button></td>"+
              "<td><button type='button' onclick='showVal(this)'>Show</button></td>";
@@ -40,6 +41,7 @@ function saveCfg(e){
     var r=rows[i];
     data.append('s'+(i-1),r.querySelector('.s').value);
     data.append('r'+(i-1),r.querySelector('.r').value);
+    data.append('n'+(i-1),r.querySelector('.n').value);
     data.append('t'+(i-1),r.querySelector('.t').value);
   }
   fetch('/config',{method:'POST',body:data}).then(()=>location.reload());


### PR DESCRIPTION
## Summary
- add length field for each mapping entry
- poll ranges of registers at once
- store and load configuration via `Preferences`
- extend Modbus table to support up to 1200 holding registers
- update web UI for range support

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_688b0ff043508324b93997ea9bb9ed6e