### PR TITLE
Add basic password protection

### DIFF
--- a/SW/ESPlan_RS485_ModbusTCP_Gateway/ESPlan_RS485_ModbusTCP_Gateway.ino
+++ b/SW/ESPlan_RS485_ModbusTCP_Gateway/ESPlan_RS485_ModbusTCP_Gateway.ino
@@ -31,6 +31,10 @@
 #include "script.h"
 #include "styles.h"
 
+// Simple passwords stored in flash memory
+const char* CONFIG_PASSWORD = "admin";     // password required to save config
+const char* OTA_PASSWORD    = "otapass";   // password for OTA updates
+
 // RS485 serial pins on ESPlan
 #define RS485_RX 36
 #define RS485_TX 4
@@ -131,6 +135,10 @@ void handleConfigGet()
 
 void handleConfigPost()
 {
+    if(!server.hasArg("pass") || server.arg("pass") != CONFIG_PASSWORD){
+        server.send(401, "text/plain", "Wrong password");
+        return;
+    }
     if (server.hasArg("baud"))
     {
         baudrate = server.arg("baud").toInt();
@@ -338,6 +346,7 @@ void setup()
     ETH.config(local_IP, gateway, subnet, dns, dns);
 
     ArduinoOTA.setHostname("esplan");
+    ArduinoOTA.setPassword(OTA_PASSWORD);
     ArduinoOTA.begin();
 
     Serial1.begin(baudrate, SERIAL_8N1, RS485_RX, RS485_TX);

--- a/SW/ESPlan_RS485_ModbusTCP_Gateway/script.h
+++ b/SW/ESPlan_RS485_ModbusTCP_Gateway/script.h
@@ -74,7 +74,16 @@ function saveCfg(e){
       }
     }
   }
-  fetch('/config',{method:'POST',body:data}).then(()=>location.reload());
+  var pass=prompt('Enter password');
+  if(pass===null)return;
+  data.append('pass',pass);
+  fetch('/config',{method:'POST',body:data}).then(r=>{
+    if(r.status==401){
+      alert('Wrong password');
+    }else{
+      location.reload();
+    }
+  });
 }
 function updateClients(){
   fetch('/clients').then(r=>r.json()).then(data=>{


### PR DESCRIPTION
## Summary
- secure configuration saving via password check
- require OTA updates to use a password
- prompt for password in the web UI before saving settings

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_b_688b3519feb48324ae174bb535dc8c0d