### PR TITLE
Update gateway web interface layout

### DIFF
--- a/SW/ESPlan_RS485_ModbusTCP_Gateway/index.h
+++ b/SW/ESPlan_RS485_ModbusTCP_Gateway/index.h
@@ -19,12 +19,12 @@ const char index_html[] PROGMEM = R"rawliteral(
                 <div class='field'><label>Mask</label><input id='mask' name='mask'></div>
                 <div class='field'><label>Baud</label><input id='baud' name='baud'></div>
                 <div class='field'><label>Port</label><input id='port' name='port'></div>
-                <div class='field'><label>Clients</label><div class='clientsWrap'><span id='clients'>0</span><button type='button' id='showClients' class='icon'><span class='material-icons'>visibility</span></button></div></div>
-                <div class='field'><label>Cycle time</label><span id='cycle'>0</span> ms</div>
+                <div class='field'><label>Clients</label><div class='clientsWrap'><span id='clients'>0</span><button type='button' id='showClients' class='icon' title='Show clients'><span class='material-icons'>visibility</span></button></div></div>
+                <div class='field'><label>Cycle time</label><div class='cycleWrap'><span id='cycle'>0</span> ms</div></div>
             </div>
             <div class='tableWrap'>
                 <table id='map'>
-                    <tr><th>Slave</th><th>Reg</th><th>Len</th><th>TCP</th><th>End</th><th></th><th></th></tr>
+                    <tr><th>Slave</th><th>Reg</th><th>Len</th><th>TCP</th><th>End</th><th>Action</th></tr>
                 </table>
                 <button type='button' id='add'><span class='material-icons'>add</span></button>
             </div>

--- a/SW/ESPlan_RS485_ModbusTCP_Gateway/script.h
+++ b/SW/ESPlan_RS485_ModbusTCP_Gateway/script.h
@@ -10,8 +10,8 @@ function addRow(item){
              "<td><input class='n' type='number' min='1' value='"+(item?item.n:1)+"'></td>"+
              "<td><input class='t' type='number' min='0' value='"+(item?item.t:0)+"'></td>"+
              "<td class='end'></td>"+
-             "<td><button type='button' onclick='delRow(this)' class='icon'><span class='material-icons'>delete</span></button></td>"+
-             "<td><button type='button' onclick='showVal(this)'>Show</button></td>";
+             "<td class='actionWrap'><button type='button' onclick='showVal(this)' class='icon' title='Show'><span class='material-icons'>visibility</span></button> "+
+             "<button type='button' onclick='delRow(this)' class='icon' title='Delete'><span class='material-icons'>delete</span></button></td>";
   updateEnd(r);
   r.querySelector('.n').addEventListener('input',()=>updateEnd(r));
   r.querySelector('.t').addEventListener('input',()=>updateEnd(r));

--- a/SW/ESPlan_RS485_ModbusTCP_Gateway/styles.h
+++ b/SW/ESPlan_RS485_ModbusTCP_Gateway/styles.h
@@ -15,8 +15,11 @@ button:not(.icon):hover,input:hover[type=submit]{color:black;background-color:li
 .icon{background:none;border:none;padding:0;}
 .tableWrap{display:flex;flex-direction:row;align-items:flex-end;}
 .clientsWrap{display:flex;align-items:center;gap:4px;}
+.cycleWrap{display:flex;align-items:center;gap:4px;}
+.actionWrap{display:flex;gap:4px;}
 #add{margin-left:8px;margin-bottom:1px;height:30px;width:30px;}
 #add span{position:relative;left:-6px;font-size:20px;}
+#restart,#save{width:110px;}
 #restart{margin-left:10px;}
 )rawliteral";
 #endif


### PR DESCRIPTION
## Summary
- tweak gateway interface styles and layout
- combine show/delete into Action column
- use eye icon for show buttons
- unify restart/save widths and add cycle/clients wrappers

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_688c47b345a88324836fa8a2692146d0