### PR TITLE
Improve Modbus polling

### DIFF
--- a/SW/ESPlan_RS485_ModbusTCP_Gateway/index.h
+++ b/SW/ESPlan_RS485_ModbusTCP_Gateway/index.h
@@ -19,6 +19,7 @@ const char index_html[] PROGMEM = R"rawliteral(
                 <div class='field'><label>Mask</label><input id='mask' name='mask'></div>
                 <div class='field'><label>Baud</label><input id='baud' name='baud'></div>
                 <div class='field'><label>Port</label><input id='port' name='port'></div>
+                <div class='field'><label>Split</label><input id='split' name='split'></div>
                 <div class='field'><label>Clients</label><div class='clientsWrap'><span id='clients'>0</span><button type='button' id='showClients' class='icon' title='Show clients'><span class='material-icons'>visibility</span></button></div></div>
                 <div class='field'><label>Cycle time</label><div class='cycleWrap'><span id='cycle'>0</span> ms</div></div>
             </div>

--- a/SW/ESPlan_RS485_ModbusTCP_Gateway/script.h
+++ b/SW/ESPlan_RS485_ModbusTCP_Gateway/script.h
@@ -38,6 +38,7 @@ function loadCfg(){
     document.getElementById('mask').value=cfg.mask;
     document.getElementById('baud').value=cfg.baud;
     document.getElementById('port').value=cfg.port;
+    document.getElementById('split').value=cfg.split;
     cfg.items.forEach(addRow);
   });
 }
@@ -51,6 +52,7 @@ function saveCfg(e){
   data.append('mask',document.getElementById('mask').value);
   data.append('baud',document.getElementById('baud').value);
   data.append('port',document.getElementById('port').value);
+  data.append('split',document.getElementById('split').value);
   data.append('count',rows.length-1);
   for(var i=1;i<rows.length;i++){
     var r=rows[i];


### PR DESCRIPTION
## Summary
- set default limit for Modbus reads to 50 registers
- constrain chunk size and add delay between Modbus queries
- clear response buffer before each Modbus transaction

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_b_688c58d5ba488324ae1624c4d7167b8f